### PR TITLE
added IANA vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See the list of rake tasks in the `vocab` namespace for specific vocabulary gene
 - RDF::Vocab::EDM - [Europeana Data Model](http://labs.europeana.eu/api/linked-open-data/data-structure/)
 - RDF::Vocab::Fcrepo3 (module) - [Fedora Commons Repository 3](https://github.com/fcrepo3)*
 - RDF::Vocab::Fcrepo4 - [Fedora Commons Repository 4 Ontology](http://fedora.info/definitions/v4/repository)
+- RDF::Vocab::IANA - [Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml) (IANA)
 - RDF::Vocab::Identifiers - [Standard Identifiers Scheme](http://id.loc.gov/vocabulary/identifiers.html) (LoC)
 - RDF::Vocab::LDP - [Linked Data Platform](http://www.w3.org/TR/ldp/) (W3C)
 - RDF::Vocab::MADS - [Metadata Authority Description Schema](http://www.loc.gov/standards/mads/) (LoC) 

--- a/lib/rdf-vocab/config/vocab.yml
+++ b/lib/rdf-vocab/config/vocab.yml
@@ -56,6 +56,16 @@ fcrepo4:
   class_name: Fcrepo4
   uri: http://fedora.info/definitions/v4/repository#
   source: http://fedora.info/definitions/v4/2015/02/04/repository
+# IANA publishes the Link Relation Types as an XML file, but not as RDF.
+# See: http://www.iana.org/assignments/link-relations/link-relations.xml
+# In order to generate an RDF representation of this file, the XSLT file at
+# ./sources/iana-relation.xsl is applied, the result of which is stored
+# in ./sources/iana-relation.rdf It is from that file that the Ruby
+# representation is generated.
+iana:
+  class_name: IANA
+  uri: http://www.iana.org/assignments/relation/
+  source: iana-relation.rdf
 identifiers:
   class_name: Identifiers
   uri: http://id.loc.gov/vocabulary/identifiers/

--- a/lib/rdf-vocab/vocab/iana.rb
+++ b/lib/rdf-vocab/vocab/iana.rb
@@ -1,0 +1,412 @@
+# -*- encoding: utf-8 -*-
+# This file generated automatically using vocab-fetch from /Users/acoburn/Projects/rdf-vocab/sources/iana-relation.rdf
+require 'rdf'
+module RDF::Vocab
+  class IANA < RDF::StrictVocabulary("http://www.iana.org/assignments/relation/")
+
+    # Property definitions
+    property :about,
+      comment: %(Refers to a resource that is the subject of the link's context.).freeze,
+      label: "about".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :alternate,
+      comment: %(Refers to a substitute for this context).freeze,
+      label: "alternate".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :appendix,
+      comment: %(Refers to an appendix.).freeze,
+      label: "appendix".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :archives,
+      comment: %(Refers to a collection of records, documents, or other materials of historical
+        interest.).freeze,
+      label: "archives".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :author,
+      comment: %(Refers to the context's author.).freeze,
+      label: "author".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :bookmark,
+      comment: %(Gives a permanent link to use for bookmarking purposes.).freeze,
+      label: "bookmark".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :canonical,
+      comment: %(Designates the preferred version of a resource \(the IRI and its
+        contents\).).freeze,
+      label: "canonical".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :chapter,
+      comment: %(Refers to a chapter in a collection of resources.).freeze,
+      label: "chapter".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :collection,
+      comment: %(The target IRI points to a resource which represents the collection resource for
+        the context IRI.).freeze,
+      label: "collection".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :contents,
+      comment: %(Refers to a table of contents.).freeze,
+      label: "contents".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :copyright,
+      comment: %(Refers to a copyright statement that applies to the link's context.).freeze,
+      label: "copyright".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"create-form",
+      comment: %(The target IRI points to a resource where a submission form can be
+        obtained.).freeze,
+      label: "create-form".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :current,
+      comment: %(Refers to a resource containing the most recent item\(s\) in a collection of
+        resources.).freeze,
+      label: "current".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :derivedfrom,
+      comment: %(The target IRI points to a resource from which this material was
+        derived.).freeze,
+      label: "derivedfrom".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :describedby,
+      comment: %(Refers to a resource providing information about the link's
+        context.).freeze,
+      label: "describedby".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :describes,
+      comment: %(The relationship A 'describes' B asserts that resource A provides a description
+        of resource B. There are no constraints on the format or representation of either A or B,
+        neither are there any further constraints on either resource.).freeze,
+      label: "describes".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :disclosure,
+      comment: %(Refers to a list of patent disclosures made with respect to material for which
+        'disclosure' relation is specified.).freeze,
+      label: "disclosure".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :duplicate,
+      comment: %(Refers to a resource whose available representations are byte-for-byte identical
+        with the corresponding representations of the context IRI.).freeze,
+      label: "duplicate".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :edit,
+      comment: %(Refers to a resource that can be used to edit the link's context.).freeze,
+      label: "edit".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"edit-form",
+      comment: %(The target IRI points to a resource where a submission form for editing
+        associated resource can be obtained.).freeze,
+      label: "edit-form".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"edit-media",
+      comment: %(Refers to a resource that can be used to edit media associated with the link's
+        context.).freeze,
+      label: "edit-media".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :enclosure,
+      comment: %(Identifies a related resource that is potentially large and might require special
+        handling.).freeze,
+      label: "enclosure".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :first,
+      comment: %(An IRI that refers to the furthest preceding resource in a series of
+        resources.).freeze,
+      label: "first".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :glossary,
+      comment: %(Refers to a glossary of terms.).freeze,
+      label: "glossary".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :help,
+      comment: %(Refers to context-sensitive help.).freeze,
+      label: "help".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :hosts,
+      comment: %(Refers to a resource hosted by the server indicated by the link
+        context.).freeze,
+      label: "hosts".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :hub,
+      comment: %(Refers to a hub that enables registration for notification of updates to the
+        context.).freeze,
+      label: "hub".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :icon,
+      comment: %(Refers to an icon representing the link's context.).freeze,
+      label: "icon".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :index,
+      comment: %(Refers to an index.).freeze,
+      label: "index".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :item,
+      comment: %(The target IRI points to a resource that is a member of the collection
+        represented by the context IRI.).freeze,
+      label: "item".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :last,
+      comment: %(An IRI that refers to the furthest following resource in a series of
+        resources.).freeze,
+      label: "last".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"latest-version",
+      comment: %(Points to a resource containing the latest \(e.g., current\) version of the
+        context.).freeze,
+      label: "latest-version".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :license,
+      comment: %(Refers to a license associated with this context.).freeze,
+      label: "license".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :lrdd,
+      comment: %(Refers to further information about the link's context, expressed as a LRDD
+        \("Link-based Resource Descriptor Document"\) resource. See 
+        for information about processing this relation type in host-meta documents. When used
+        elsewhere, it refers to additional links and other metadata. Multiple instances indicate
+        additional LRDD resources. LRDD resources MUST have an "application/xrd+xml" representation,
+        and MAY have others.).freeze,
+      label: "lrdd".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :memento,
+      comment: %(The Target IRI points to a Memento, a fixed resource that will not change state
+        anymore.).freeze,
+      label: "memento".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :monitor,
+      comment: %(Refers to a resource that can be used to monitor changes in an HTTP resource. ).freeze,
+      label: "monitor".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"monitor-group",
+      comment: %(Refers to a resource that can be used to monitor changes in a specified group of
+        HTTP resources. ).freeze,
+      label: "monitor-group".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :next,
+      comment: %(Indicates that the link's context is a part of a series, and that the next in the
+        series is the link target. ).freeze,
+      label: "next".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"next-archive",
+      comment: %(Refers to the immediately following archive resource.).freeze,
+      label: "next-archive".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :nofollow,
+      comment: %(Indicates that the context’s original author or publisher does not endorse the
+        link target.).freeze,
+      label: "nofollow".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :noreferrer,
+      comment: %(Indicates that no referrer information is to be leaked when following the
+        link.).freeze,
+      label: "noreferrer".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :original,
+      comment: %(The Target IRI points to an Original Resource.).freeze,
+      label: "original".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :payment,
+      comment: %(Indicates a resource where payment is accepted.).freeze,
+      label: "payment".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"predecessor-version",
+      comment: %(Points to a resource containing the predecessor version in the version history. ).freeze,
+      label: "predecessor-version".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :prefetch,
+      comment: %(Indicates that the link target should be preemptively cached.).freeze,
+      label: "prefetch".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :prev,
+      comment: %(Indicates that the link's context is a part of a series, and that the previous in
+        the series is the link target. ).freeze,
+      label: "prev".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"prev-archive",
+      comment: %(Refers to the immediately preceding archive resource.).freeze,
+      label: "prev-archive".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :preview,
+      comment: %(Refers to a resource that provides a preview of the link's context.).freeze,
+      label: "preview".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :previous,
+      comment: %(Refers to the previous resource in an ordered series of resources. Synonym for
+        "prev".).freeze,
+      label: "previous".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"privacy-policy",
+      comment: %(Refers to a privacy policy associated with the link's context.).freeze,
+      label: "privacy-policy".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :profile,
+      comment: %(Identifying that a resource representation conforms to a certain profile, without
+        affecting the non-profile semantics of the resource representation.).freeze,
+      label: "profile".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :related,
+      comment: %(Identifies a related resource.).freeze,
+      label: "related".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :replies,
+      comment: %(Identifies a resource that is a reply to the context of the link. ).freeze,
+      label: "replies".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :search,
+      comment: %(Refers to a resource that can be used to search through the link's context and
+        related resources.).freeze,
+      label: "search".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :section,
+      comment: %(Refers to a section in a collection of resources.).freeze,
+      label: "section".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :self,
+      comment: %(Conveys an identifier for the link's context. ).freeze,
+      label: "self".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :service,
+      comment: %(Indicates a URI that can be used to retrieve a service document.).freeze,
+      label: "service".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :start,
+      comment: %(Refers to the first resource in a collection of resources.).freeze,
+      label: "start".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :stylesheet,
+      comment: %(Refers to a stylesheet.).freeze,
+      label: "stylesheet".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :subsection,
+      comment: %(Refers to a resource serving as a subsection in a collection of
+        resources.).freeze,
+      label: "subsection".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"successor-version",
+      comment: %(Points to a resource containing the successor version in the version history. ).freeze,
+      label: "successor-version".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :tag,
+      comment: %(Gives a tag \(identified by the given address\) that applies to the current
+        document. ).freeze,
+      label: "tag".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"terms-of-service",
+      comment: %(Refers to the terms of service associated with the link's context.).freeze,
+      label: "terms-of-service".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :timegate,
+      comment: %(The Target IRI points to a TimeGate for an Original Resource.).freeze,
+      label: "timegate".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :timemap,
+      comment: %(The Target IRI points to a TimeMap for an Original Resource.).freeze,
+      label: "timemap".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :type,
+      comment: %(Refers to a resource identifying the abstract semantic type of which the link's
+        context is considered to be an instance.).freeze,
+      label: "type".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :up,
+      comment: %(Refers to a parent document in a hierarchy of documents. ).freeze,
+      label: "up".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"version-history",
+      comment: %(Points to a resource containing the version history for the context. ).freeze,
+      label: "version-history".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :via,
+      comment: %(Identifies a resource that is the source of the information in the link's
+        context. ).freeze,
+      label: "via".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"working-copy",
+      comment: %(Points to a working copy for this resource.).freeze,
+      label: "working-copy".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+    property :"working-copy-of",
+      comment: %(Points to the versioned resource from which this working copy was obtained. ).freeze,
+      label: "working-copy-of".freeze,
+      "rdfs:isDefinedBy" => %(http://www.iana.org/assignments/relation/).freeze,
+      type: "rdf:Property".freeze
+
+    # Extra definitions
+    term :"",
+      "dc:contributor" => %(Mark Nottingham, Julian Reschke, Jan Algermissen).freeze,
+      "dc:created" => %(2005-08-26).freeze,
+      "dc:modified" => %(2015-01-21).freeze,
+      "dc:publisher" => %(http://www.iana.org/).freeze,
+      "dc:title" => %(Link Relations).freeze,
+      label: "".freeze,
+      "rdfs:seeAlso" => %(http://www.iana.org/assignments/link-relations/link-relations.xhtml).freeze
+  end
+end

--- a/sources/iana-relation.rdf
+++ b/sources/iana-relation.rdf
@@ -1,0 +1,475 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
+  <rdf:Description rdf:about="http://www.iana.org/assignments/relation/">
+    <dcterms:title xml:lang="en">Link Relations</dcterms:title>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2005-08-26</dcterms:created>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-01-21</dcterms:modified>
+    <dcterms:publisher rdf:resource="http://www.iana.org/"/>
+    <dcterms:contributor>Mark Nottingham, Julian Reschke, Jan Algermissen</dcterms:contributor>
+    <rdfs:seeAlso rdf:resource="http://www.iana.org/assignments/link-relations/link-relations.xhtml"/>
+  </rdf:Description>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/about">
+    <rdfs:label xml:lang="en">about</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that is the subject of the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6903, section 2"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/alternate">
+    <rdfs:label xml:lang="en">alternate</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a substitute for this context</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-alternate"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/appendix">
+    <rdfs:label xml:lang="en">appendix</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to an appendix.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/archives">
+    <rdfs:label xml:lang="en">archives</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a collection of records, documents, or other materials of historical
+        interest.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/2011/WD-html5-20110113/links.html#rel-archives"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/author">
+    <rdfs:label xml:lang="en">author</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the context's author.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-author"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/bookmark">
+    <rdfs:label xml:lang="en">bookmark</rdfs:label>
+    <rdfs:comment xml:lang="en">Gives a permanent link to use for bookmarking purposes.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-bookmark"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/canonical">
+    <rdfs:label xml:lang="en">canonical</rdfs:label>
+    <rdfs:comment xml:lang="en">Designates the preferred version of a resource (the IRI and its
+        contents).</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6596"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/chapter">
+    <rdfs:label xml:lang="en">chapter</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a chapter in a collection of resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/collection">
+    <rdfs:label xml:lang="en">collection</rdfs:label>
+    <rdfs:comment xml:lang="en">The target IRI points to a resource which represents the collection resource for
+        the context IRI.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6573"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/contents">
+    <rdfs:label xml:lang="en">contents</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a table of contents.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/copyright">
+    <rdfs:label xml:lang="en">copyright</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a copyright statement that applies to the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/create-form">
+    <rdfs:label xml:lang="en">create-form</rdfs:label>
+    <rdfs:comment xml:lang="en">The target IRI points to a resource where a submission form can be
+        obtained.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6861"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/current">
+    <rdfs:label xml:lang="en">current</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource containing the most recent item(s) in a collection of
+        resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5005"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/derivedfrom">
+    <rdfs:label xml:lang="en">derivedfrom</rdfs:label>
+    <rdfs:comment xml:lang="en">The target IRI points to a resource from which this material was
+        derived.</rdfs:comment>
+    <rdfs:seeAlso rdf:about=""/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/describedby">
+    <rdfs:label xml:lang="en">describedby</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource providing information about the link's
+        context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/powder-dr/#assoc-linking"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/describes">
+    <rdfs:label xml:lang="en">describes</rdfs:label>
+    <rdfs:comment xml:lang="en">The relationship A 'describes' B asserts that resource A provides a description
+        of resource B. There are no constraints on the format or representation of either A or B,
+        neither are there any further constraints on either resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6892"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/disclosure">
+    <rdfs:label xml:lang="en">disclosure</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a list of patent disclosures made with respect to material for which
+        'disclosure' relation is specified.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6579"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/duplicate">
+    <rdfs:label xml:lang="en">duplicate</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource whose available representations are byte-for-byte identical
+        with the corresponding representations of the context IRI.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6249"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/edit">
+    <rdfs:label xml:lang="en">edit</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that can be used to edit the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5023"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/edit-form">
+    <rdfs:label xml:lang="en">edit-form</rdfs:label>
+    <rdfs:comment xml:lang="en">The target IRI points to a resource where a submission form for editing
+        associated resource can be obtained.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6861"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/edit-media">
+    <rdfs:label xml:lang="en">edit-media</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that can be used to edit media associated with the link's
+        context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5023"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/enclosure">
+    <rdfs:label xml:lang="en">enclosure</rdfs:label>
+    <rdfs:comment xml:lang="en">Identifies a related resource that is potentially large and might require special
+        handling.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4287"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/first">
+    <rdfs:label xml:lang="en">first</rdfs:label>
+    <rdfs:comment xml:lang="en">An IRI that refers to the furthest preceding resource in a series of
+        resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5988"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/glossary">
+    <rdfs:label xml:lang="en">glossary</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a glossary of terms.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/help">
+    <rdfs:label xml:lang="en">help</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to context-sensitive help.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-help"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/hosts">
+    <rdfs:label xml:lang="en">hosts</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource hosted by the server indicated by the link
+        context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6690"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/hub">
+    <rdfs:label xml:lang="en">hub</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a hub that enables registration for notification of updates to the
+        context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://pubsubhubbub.googlecode.com"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/icon">
+    <rdfs:label xml:lang="en">icon</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to an icon representing the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-icon"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/index">
+    <rdfs:label xml:lang="en">index</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to an index.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/item">
+    <rdfs:label xml:lang="en">item</rdfs:label>
+    <rdfs:comment xml:lang="en">The target IRI points to a resource that is a member of the collection
+        represented by the context IRI.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6573"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/last">
+    <rdfs:label xml:lang="en">last</rdfs:label>
+    <rdfs:comment xml:lang="en">An IRI that refers to the furthest following resource in a series of
+        resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5988"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/latest-version">
+    <rdfs:label xml:lang="en">latest-version</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to a resource containing the latest (e.g., current) version of the
+        context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/license">
+    <rdfs:label xml:lang="en">license</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a license associated with this context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4946"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/lrdd">
+    <rdfs:label xml:lang="en">lrdd</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to further information about the link's context, expressed as a LRDD
+        ("Link-based Resource Descriptor Document") resource. See 
+        for information about processing this relation type in host-meta documents. When used
+        elsewhere, it refers to additional links and other metadata. Multiple instances indicate
+        additional LRDD resources. LRDD resources MUST have an "application/xrd+xml" representation,
+        and MAY have others.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6415"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/memento">
+    <rdfs:label xml:lang="en">memento</rdfs:label>
+    <rdfs:comment xml:lang="en">The Target IRI points to a Memento, a fixed resource that will not change state
+        anymore.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc7089"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/monitor">
+    <rdfs:label xml:lang="en">monitor</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that can be used to monitor changes in an HTTP resource. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5989"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/monitor-group">
+    <rdfs:label xml:lang="en">monitor-group</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that can be used to monitor changes in a specified group of
+        HTTP resources. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5989"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/next">
+    <rdfs:label xml:lang="en">next</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that the link's context is a part of a series, and that the next in the
+        series is the link target. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-next"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/next-archive">
+    <rdfs:label xml:lang="en">next-archive</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the immediately following archive resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5005"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/nofollow">
+    <rdfs:label xml:lang="en">nofollow</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that the context&#x2019;s original author or publisher does not endorse the
+        link target.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-nofollow"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/noreferrer">
+    <rdfs:label xml:lang="en">noreferrer</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that no referrer information is to be leaked when following the
+        link.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-noreferrer"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/original">
+    <rdfs:label xml:lang="en">original</rdfs:label>
+    <rdfs:comment xml:lang="en">The Target IRI points to an Original Resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc7089"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/payment">
+    <rdfs:label xml:lang="en">payment</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates a resource where payment is accepted.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5988"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/predecessor-version">
+    <rdfs:label xml:lang="en">predecessor-version</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to a resource containing the predecessor version in the version history. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/prefetch">
+    <rdfs:label xml:lang="en">prefetch</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that the link target should be preemptively cached.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-prefetch"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/prev">
+    <rdfs:label xml:lang="en">prev</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that the link's context is a part of a series, and that the previous in
+        the series is the link target. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-prev"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/preview">
+    <rdfs:label xml:lang="en">preview</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that provides a preview of the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6903, section 3"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/previous">
+    <rdfs:label xml:lang="en">previous</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the previous resource in an ordered series of resources. Synonym for
+        "prev".</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/prev-archive">
+    <rdfs:label xml:lang="en">prev-archive</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the immediately preceding archive resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5005"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/privacy-policy">
+    <rdfs:label xml:lang="en">privacy-policy</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a privacy policy associated with the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6903, section 4"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/profile">
+    <rdfs:label xml:lang="en">profile</rdfs:label>
+    <rdfs:comment xml:lang="en">Identifying that a resource representation conforms to a certain profile, without
+        affecting the non-profile semantics of the resource representation.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6906"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/related">
+    <rdfs:label xml:lang="en">related</rdfs:label>
+    <rdfs:comment xml:lang="en">Identifies a related resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4287"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/replies">
+    <rdfs:label xml:lang="en">replies</rdfs:label>
+    <rdfs:comment xml:lang="en">Identifies a resource that is a reply to the context of the link. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4685"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/search">
+    <rdfs:label xml:lang="en">search</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource that can be used to search through the link's context and
+        related resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.opensearch.org/Specifications/OpenSearch/1.1"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/section">
+    <rdfs:label xml:lang="en">section</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a section in a collection of resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/self">
+    <rdfs:label xml:lang="en">self</rdfs:label>
+    <rdfs:comment xml:lang="en">Conveys an identifier for the link's context. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4287"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/service">
+    <rdfs:label xml:lang="en">service</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates a URI that can be used to retrieve a service document.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5023"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/start">
+    <rdfs:label xml:lang="en">start</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the first resource in a collection of resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/stylesheet">
+    <rdfs:label xml:lang="en">stylesheet</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a stylesheet.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-stylesheet"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/subsection">
+    <rdfs:label xml:lang="en">subsection</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource serving as a subsection in a collection of
+        resources.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/1999/REC-html401-19991224"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/successor-version">
+    <rdfs:label xml:lang="en">successor-version</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to a resource containing the successor version in the version history. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/tag">
+    <rdfs:label xml:lang="en">tag</rdfs:label>
+    <rdfs:comment xml:lang="en">Gives a tag (identified by the given address) that applies to the current
+        document. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="http://www.w3.org/TR/html5/links.html#link-type-tag"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/terms-of-service">
+    <rdfs:label xml:lang="en">terms-of-service</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to the terms of service associated with the link's context.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6903, section 5"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/timegate">
+    <rdfs:label xml:lang="en">timegate</rdfs:label>
+    <rdfs:comment xml:lang="en">The Target IRI points to a TimeGate for an Original Resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc7089"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/timemap">
+    <rdfs:label xml:lang="en">timemap</rdfs:label>
+    <rdfs:comment xml:lang="en">The Target IRI points to a TimeMap for an Original Resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc7089"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/type">
+    <rdfs:label xml:lang="en">type</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a resource identifying the abstract semantic type of which the link's
+        context is considered to be an instance.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc6903, section 6"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/up">
+    <rdfs:label xml:lang="en">up</rdfs:label>
+    <rdfs:comment xml:lang="en">Refers to a parent document in a hierarchy of documents. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5988"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/version-history">
+    <rdfs:label xml:lang="en">version-history</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to a resource containing the version history for the context. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/via">
+    <rdfs:label xml:lang="en">via</rdfs:label>
+    <rdfs:comment xml:lang="en">Identifies a resource that is the source of the information in the link's
+        context. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc4287"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/working-copy">
+    <rdfs:label xml:lang="en">working-copy</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to a working copy for this resource.</rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.iana.org/assignments/relation/working-copy-of">
+    <rdfs:label xml:lang="en">working-copy-of</rdfs:label>
+    <rdfs:comment xml:lang="en">Points to the versioned resource from which this working copy was obtained. </rdfs:comment>
+    <rdfs:seeAlso rdf:about="rfc5829"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.iana.org/assignments/relation/"/>
+  </rdf:Property>
+</rdf:RDF>

--- a/sources/iana-relation.xsl
+++ b/sources/iana-relation.xsl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:dcterms="http://purl.org/dc/terms/"    
+    xmlns:iana="http://www.iana.org/assignments"
+    exclude-result-prefixes="xs iana"
+    version="1.0">
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:variable name="relation" select="'http://www.iana.org/assignments/relation/'"/>
+    <xsl:template match="/iana:registry">
+        <rdf:RDF>
+            <rdf:Description>
+                <xsl:attribute name="rdf:about">
+                    <xsl:value-of select="$relation"/>
+                </xsl:attribute>
+                <dcterms:title xml:lang="en">
+                    <xsl:value-of select="iana:title"/>
+                </dcterms:title>
+                <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="iana:created"/>
+                </dcterms:created>
+                <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">
+                    <xsl:value-of select="iana:updated"/>
+                </dcterms:modified>
+                <dcterms:publisher rdf:resource="http://www.iana.org/"/>
+                <dcterms:contributor>
+                    <xsl:value-of select="iana:registry/iana:expert[1]"/>
+                </dcterms:contributor>
+                <rdfs:seeAlso rdf:resource="http://www.iana.org/assignments/link-relations/link-relations.xhtml"/>
+            </rdf:Description>
+            
+            <xsl:for-each select="iana:registry/iana:record">
+                <rdf:Property>
+                    <xsl:attribute name="rdf:about">
+                        <xsl:value-of select="$relation"/>
+                        <xsl:value-of select="iana:value"/>
+                    </xsl:attribute>
+                    <rdfs:label xml:lang="en"><xsl:value-of select="iana:value"/></rdfs:label>
+                    <rdfs:comment xml:lang="en"><xsl:value-of select="iana:description"/></rdfs:comment>
+                    <xsl:if test="iana:spec/iana:xref[@type='rfc' or @type='uri']"></xsl:if>
+                    <rdfs:seeAlso>
+                        <xsl:attribute name="rdf:about">
+                            <xsl:choose>
+                                <xsl:when test="iana:spec/iana:xref[@type='rfc']">
+                                    <xsl:value-of select="iana:spec/iana:xref/@data"/>
+                                    <xsl:value-of select="iana:spec/text()"/>
+                                </xsl:when>
+                                <xsl:when test="iana:spec/iana:xref[@type='uri']">
+                                    <xsl:value-of select="iana:spec/iana:xref/@data"/>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                    </rdfs:seeAlso>
+                    <rdfs:isDefinedBy>
+                        <xsl:attribute name="rdf:resource">
+                            <xsl:value-of select="$relation"/>
+                        </xsl:attribute>
+                    </rdfs:isDefinedBy>
+                </rdf:Property>
+            </xsl:for-each>
+        </rdf:RDF>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This adds the IANA link relation terms.

IANA does not publish these terms as RDF, but they do publish them as XML, so this PR includes an XSL stylesheet to transform that XML representation into RDF (`./sources/iana-relation.xsl`). The generated RDF file is also included (`./sources/iana-relation.rdf`).
